### PR TITLE
Fixing command aliases

### DIFF
--- a/lib/Term/Shell.pm
+++ b/lib/Term/Shell.pm
@@ -317,6 +317,19 @@ sub add_handlers
             $a .= $o->cmd_suffix;
         }
         $o->{handlers}{$a}{$t} = $hnd;
+    }
+    for my $hnd (@_)
+    {
+        next unless $hnd =~ /^(run|help|smry|comp|catch|alias)_/o;
+        my $t = $1;
+        my $a = substr( $hnd, length($t) + 1 );
+
+        # Add on the prefix and suffix if the command is defined
+        if ( length $a )
+        {
+            substr( $a, 0, 0 ) = $o->cmd_prefix;
+            $a .= $o->cmd_suffix;
+        }
         if ( $o->has_aliases($a) )
         {
             my @a = $o->get_aliases($a);


### PR DESCRIPTION
Currently, due to the way that methods are searched in $pkg:: which
is an unordered hash and how add_handlers() works, behavior of
command aliases is random and incorrect.

(Sometimes aliases are installed, sometimes not, and sometimes they
are categorized as extra/non-command aliases.)

This is happening because add_handlers() is checking for command
aliases before it has seen/processed all the commands.

The suggested fix solves the issue by splitting the loop in two
identical passes, avoiding the issue. Please modify/improve in any
way that would be needed from here.