### PR TITLE
Discrepancy between distro and Shell.pm version number

### DIFF
--- a/lib/Term/Shell.pm
+++ b/lib/Term/Shell.pm
@@ -8,7 +8,7 @@ use 5.014;
 use Data::Dumper;
 use Term::ReadLine ();
 
-our $VERSION = '0.10';
+our $VERSION = '0.12';
 
 #=============================================================================
 # Term::Shell API methods


### PR DESCRIPTION
Current distribution version is 0.12 but Term::Shell has 0.10